### PR TITLE
Add Sanctum authentication

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+
+class AuthController extends Controller
+{
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'email' => ['required', 'email', 'unique:users'],
+            'password' => ['required', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        return response()->json([
+            'token' => $user->createToken('auth_token')->plainTextToken,
+        ], 201);
+    }
+
+    public function login(Request $request)
+    {
+        $data = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        $user = User::where('email', $data['email'])->first();
+
+        if (! $user || ! Hash::check($data['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => [__('auth.failed')],
+            ]);
+        }
+
+        return response()->json([
+            'token' => $user->createToken('auth_token')->plainTextToken,
+        ]);
+    }
+
+    public function logout(Request $request)
+    {
+        $request->user()->currentAccessToken()?->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,11 +6,12 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "laravel/sanctum": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'api' => [
+            'driver' => 'sanctum',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\Sanctum\Sanctum;
+
+return [
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000',
+        Sanctum::currentApplicationUrlWithPort()
+    ))),
+
+    'guard' => ['web'],
+
+    'expiration' => null,
+
+    'middleware' => [
+        'verify_csrf_token' => App\Http\Middleware\VerifyCsrfToken::class,
+        'encrypt_cookies' => App\Http\Middleware\EncryptCookies::class,
+    ],
+];

--- a/database/migrations/2025_06_05_100013_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_06_05_100013_create_personal_access_tokens_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,13 @@
 <?php
 
 use App\Http\Controllers\TaskController;
+use App\Http\Controllers\AuthController;
 use Illuminate\Support\Facades\Route;
 
-Route::apiResource('tasks', TaskController::class);
+Route::post('register', [AuthController::class, 'register'])->name('register');
+Route::post('login', [AuthController::class, 'login'])->name('login');
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('logout', [AuthController::class, 'logout'])->name('logout');
+    Route::apiResource('tasks', TaskController::class);
+});

--- a/tests/Feature/TaskControllerTest.php
+++ b/tests/Feature/TaskControllerTest.php
@@ -2,6 +2,8 @@
 
 
 use App\Models\Task;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -11,6 +13,7 @@ class TaskControllerTest extends TestCase
 
     public function test_index_returns_paginated_tasks(): void
     {
+        Sanctum::actingAs(User::factory()->create());
         Task::factory()->count(3)->create();
 
         $response = $this->getJson(route('tasks.index'));
@@ -21,6 +24,7 @@ class TaskControllerTest extends TestCase
 
     public function test_store_creates_new_task(): void
     {
+        Sanctum::actingAs(User::factory()->create());
         $data = [
             'title' => 'Test Task',
             'description' => 'Description',
@@ -37,6 +41,7 @@ class TaskControllerTest extends TestCase
 
     public function test_show_returns_task(): void
     {
+        Sanctum::actingAs(User::factory()->create());
         $task = Task::factory()->create();
 
         $response = $this->getJson(route('tasks.show', $task));
@@ -47,6 +52,7 @@ class TaskControllerTest extends TestCase
 
     public function test_update_changes_task(): void
     {
+        Sanctum::actingAs(User::factory()->create());
         $task = Task::factory()->create();
 
         $data = ['title' => 'Updated title'];
@@ -62,6 +68,7 @@ class TaskControllerTest extends TestCase
 
     public function test_destroy_deletes_task(): void
     {
+        Sanctum::actingAs(User::factory()->create());
         $task = Task::factory()->create();
 
         $response = $this->deleteJson(route('tasks.destroy', $task));


### PR DESCRIPTION
## Summary
- install Sanctum package
- add API guard and Sanctum config
- create migration for personal access tokens
- implement `AuthController`
- secure task routes with `auth:sanctum`
- update tests to use Sanctum tokens

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c17f5779883319735bcb8ef41cdbf